### PR TITLE
Moves jQuery to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
   "scripts": {
     "test": "grunt test"
   },
-  "dependencies": {
-    "jquery": "^1.11.2"
-  },
   "devDependencies": {
     "browserify-shim": "^3.8.0",
     "bundle-collapser": "^1.1.0",
@@ -32,7 +29,8 @@
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-jscs": "^0.6.1",
-    "load-grunt-tasks": "^0.6.0"
+    "load-grunt-tasks": "^0.6.0",
+    "jquery": "^1.11.2"
   },
   "browserify-shim": {
     "jquery": "global:$"


### PR DESCRIPTION
This works well for me, but I’m not using jQuery. With jQuery in `dependencies`, it still gets bundled in with Browserify, so I’ve moved it to `devDependencies`.

Let me know what you think!

**Edit**

Actually, maybe this makes no sense. But shouldn’t jQuery not be required at all within this module? And then if you are using jQuery you can do something like:

``` js
$       = require('jquery');
$.fn.td = require('throttle-debounce');
```
