### PR TITLE
Add result return from callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 npm-debug.log
+.idea/

--- a/throttle.js
+++ b/throttle.js
@@ -45,7 +45,7 @@ module.exports = function ( delay, noTrailing, callback, debounceMode ) {
 		// Execute `callback` and update the `lastExec` timestamp.
 		function exec () {
 			lastExec = Number(new Date());
-			callback.apply(self, args);
+			return callback.apply(self, args);
 		}
 
 		// If `debounceMode` is true (at begin) this is used to clear the flag
@@ -57,7 +57,7 @@ module.exports = function ( delay, noTrailing, callback, debounceMode ) {
 		if ( debounceMode && !timeoutID ) {
 			// Since `wrapper` is being called for the first time and
 			// `debounceMode` is true (at begin), execute `callback`.
-			exec();
+			return exec();
 		}
 
 		// Clear any existing timeout.
@@ -68,7 +68,7 @@ module.exports = function ( delay, noTrailing, callback, debounceMode ) {
 		if ( debounceMode === undefined && elapsed > delay ) {
 			// In throttle mode, if `delay` time has been exceeded, execute
 			// `callback`.
-			exec();
+			return exec();
 
 		} else if ( noTrailing !== true ) {
 			// In trailing throttle mode, since `delay` time has not been


### PR DESCRIPTION
Sometimes callback has a return value. Like in scala.js, we may return an `Option(value)`. When callback is dropped, we get a `None` return (which is a `undefined` in javascript).

Please have a look at this, and update npm package. Thanks.