### PR TITLE
Fix JSDoc With Optional Arguments

### DIFF
--- a/debounce.js
+++ b/debounce.js
@@ -8,7 +8,7 @@ var throttle = require('./throttle');
  * very beginning of a series of calls, or at the very end.
  *
  * @param  {Number}   delay         A zero-or-greater delay in milliseconds. For event callbacks, values around 100 or 250 (or even higher) are most useful.
- * @param  {Boolean}  atBegin       Optional, defaults to false. If atBegin is false or unspecified, callback will only be executed `delay` milliseconds
+ * @param  {Boolean}  [atBegin]     Optional, defaults to false. If atBegin is false or unspecified, callback will only be executed `delay` milliseconds
  *                                  after the last debounced-function call. If atBegin is true, callback will be executed only at the first debounced-function call.
  *                                  (After the throttled-function has not been called for `delay` milliseconds, the internal counter is reset).
  * @param  {Function} callback      A function to be executed after delay milliseconds. The `this` context and all arguments are passed through, as-is,

--- a/throttle.js
+++ b/throttle.js
@@ -5,13 +5,13 @@
  * execution of handlers on events like resize and scroll.
  *
  * @param  {Number}    delay          A zero-or-greater delay in milliseconds. For event callbacks, values around 100 or 250 (or even higher) are most useful.
- * @param  {Boolean}   noTrailing     Optional, defaults to false. If noTrailing is true, callback will only execute every `delay` milliseconds while the
+ * @param  {Boolean}   [noTrailing]   Optional, defaults to false. If noTrailing is true, callback will only execute every `delay` milliseconds while the
  *                                    throttled-function is being called. If noTrailing is false or unspecified, callback will be executed one final time
  *                                    after the last throttled-function call. (After the throttled-function has not been called for `delay` milliseconds,
  *                                    the internal counter is reset)
  * @param  {Function}  callback       A function to be executed after delay milliseconds. The `this` context and all arguments are passed through, as-is,
  *                                    to `callback` when the throttled-function is executed.
- * @param  {Boolean}   debounceMode   If `debounceMode` is true (at begin), schedule `clear` to execute after `delay` ms. If `debounceMode` is false (at end),
+ * @param  {Boolean}   [debounceMode] If `debounceMode` is true (at begin), schedule `clear` to execute after `delay` ms. If `debounceMode` is false (at end),
  *                                    schedule `callback` to execute after `delay` ms.
  *
  * @return {Function}  A new, throttled, function.


### PR DESCRIPTION
Hello!

This pull request fixes JSDoc to make it consistent with the arguments meaning. This removes warnings different IDEs can produce (Intellij IDEA in particular).

Thanks!