### PR TITLE
[Typescript] Avoid using Function type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,12 @@
-declare module 'throttle-debounce' {
-  export declare function throttle<T extends (...args: any[]) => any>(
-    delay: number,
-    noTrailing: boolean,
-    callback?: T,
-    debounceMode?: boolean
-  );
+export declare function throttle<T extends (...args: any[]) => any>(
+  delay: number,
+  noTrailing: boolean,
+  callback?: T,
+  debounceMode?: boolean
+);
 
-  export declare function debounce<T extends (...args: any[]) => any>(
-    delay: number,
-    atBegin: boolean,
-    callback?: T
-  );
-}
+export declare function debounce<T extends (...args: any[]) => any>(
+  delay: number,
+  atBegin: boolean,
+  callback?: T
+);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,14 @@
 declare module 'throttle-debounce' {
-  type throttleFn = (
+  export declare function throttle<T extends (...args: any[]) => any>(
     delay: number,
     noTrailing: boolean,
-    callback?: Function,
+    callback?: T,
     debounceMode?: boolean
-  ) => Function;
+  );
 
-  type debounceFn = (
+  export declare function debounce<T extends (...args: any[]) => any>(
     delay: number,
     atBegin: boolean,
-    callback?: Function
-  ) => Function;
-
-  const throttle: throttleFn;
-  const debounce: debounceFn;
+    callback?: T
+  );
 }


### PR DESCRIPTION
Removed `Function` type, and added generic type argument for auto-inferring the function type.