### PR TITLE
use Date.now() instead of Number(new Date())

### DIFF
--- a/throttle.js
+++ b/throttle.js
@@ -43,12 +43,12 @@ export default function ( delay, noTrailing, callback, debounceMode ) {
 	function wrapper () {
 
 		var self = this;
-		var elapsed = Number(new Date()) - lastExec;
+		var elapsed = Date.now() - lastExec;
 		var args = arguments;
 
 		// Execute `callback` and update the `lastExec` timestamp.
 		function exec () {
-			lastExec = Number(new Date());
+			lastExec = Date.now();
 			callback.apply(self, args);
 		}
 


### PR DESCRIPTION
Date.now is more efficiently and intuitively