### PR TITLE
fix BABEL_ENV in Win10

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,16 +22,15 @@
   },
   "scripts": {
     "build": "rollup --config rollup.config.js",
-    "lint": "eslint '{index,lib/**/*,test/**/*}.js'",
+    "lint": "eslint {index,lib/**/*,test/**/*}.js",
     "prepublish": "npm run build",
     "prepublishOnly": "npm run build",
     "release": "np",
     "test": "npm run lint && npm run test:automated",
-    "test:automated": "BABEL_ENV=test karma start",
-    "test:automated:local": "BABEL_ENV=test karma start --local",
+    "test:automated": "cross-env BABEL_ENV=test karma start",
+    "test:automated:local": "cross-env BABEL_ENV=test karma start --local",
     "test:automated:local:watch": "npm run test:automated:local -- --auto-watch --no-single-run"
   },
-  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
@@ -40,6 +39,7 @@
     "@babel/runtime": "^7.2.0",
     "babel-loader": "^8.0.4",
     "babel-preset-niksy": "^4.1.0",
+    "cross-env": "^5.2.0",
     "eslint": "^5.4.0",
     "eslint-config-niksy": "^6.1.0",
     "eslint-plugin-extend": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^3.0.0",
     "minimist": "^1.2.0",
+    "nan": "^2.14.0",
     "np": "^3.0.4",
     "qunitjs": "^1.23.1",
     "rollup": "^1.0.0",


### PR DESCRIPTION
fix test error in Win10

1. No files matching the pattern "'{index,lib/**/*,test/**/*}.js'" were found.
```
> throttle-debounce@2.1.0 test F:\github.com\throttle-debounce
> npm run lint && npm run test:automated


> throttle-debounce@2.1.0 lint F:\github.com\throttle-debounce
> eslint '{index,lib/**/*,test/**/*}.js'


Oops! Something went wrong! :(

ESLint: 5.16.0.
No files matching the pattern "'{index,lib/**/*,test/**/*}.js'" were found.
Please check for typing mistakes in the pattern.

```

2. use cross-env BABEL_ENV instead.
```
throttle-debounce@2.1.0 test F:\github.com\throttle-debounce
npm run lint && npm run test:automated


throttle-debounce@2.1.0 lint F:\github.com\throttle-debounce
eslint {index,lib/**/*,test/**/*}.js


throttle-debounce@2.1.0 test:automated F:\github.com\throttle-debounce
BABEL_ENV=test karma start

'BABEL_ENV' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
```

3. Module 'nan' is extraneous warning fix.
![image](https://user-images.githubusercontent.com/998505/63070455-d943d880-bf4d-11e9-925d-2c91a8ea680c.png)
