### PR TITLE
fix BABEL_ENV in Win10, travis ci fail fix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - '8'
 before_install:
+  - sudo apt-get install -y chromium-browser
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   - sleep 3

--- a/package.json
+++ b/package.json
@@ -22,16 +22,15 @@
   },
   "scripts": {
     "build": "rollup --config rollup.config.js",
-    "lint": "eslint '{index,lib/**/*,test/**/*}.js'",
+    "lint": "eslint {index,lib/**/*,test/**/*}.js",
     "prepublish": "npm run build",
     "prepublishOnly": "npm run build",
     "release": "np",
     "test": "npm run lint && npm run test:automated",
-    "test:automated": "BABEL_ENV=test karma start",
-    "test:automated:local": "BABEL_ENV=test karma start --local",
+    "test:automated": "cross-env BABEL_ENV=test xvfb-run karma start",
+    "test:automated:local": "cross-env BABEL_ENV=test karma start --local",
     "test:automated:local:watch": "npm run test:automated:local -- --auto-watch --no-single-run"
   },
-  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
@@ -40,6 +39,7 @@
     "@babel/runtime": "^7.2.0",
     "babel-loader": "^8.0.4",
     "babel-preset-niksy": "^4.1.0",
+    "cross-env": "^5.2.0",
     "eslint": "^5.4.0",
     "eslint-config-niksy": "^6.1.0",
     "eslint-plugin-extend": "^0.1.1",


### PR DESCRIPTION
fix: 
1. No files matching the pattern "'{index,lib/**/*,test/**/*}.js'" were found.
2. use cross-env BABEL_ENV instead.
3. travis build fail fix.
