### PR TITLE
Avoid having Webpack load the UMD module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased][]
 
+### Changed
+
+-   Avoid having bundles like Webpack load the UMD module
+    ([#42](https://github.com/niksy/throttle-debounce/pull/42))
+
 ## [2.3.0][] - 2020-08-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Throttle and debounce functions.",
   "main": "index.cjs.js",
   "module": "index.esm.js",
-  "browser": "index.umd.js",
+  "unpkg": "index.umd.js",
+  "jsdelivr": "index.umd.js",
   "author": "Ivan Nikolić <niksy5@gmail.com> (http://ivannikolic.com)",
   "contributors": [
     "Ben Alman (http://benalman.com)"


### PR DESCRIPTION
Depending on the configuration bundlers like Webpack will load the `browser` fielder instead of the `main` file. Besides users older versions of Webpack that don't support `module` this also affects us because we currently disable `module` in our project due to some bug.

This change removes the `browser` field but forces both unpkg and jsdelivr to use the UMD version.