### PR TITLE
Update package.json exports to fix some libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     ".": {
       "import": "./esm/index.js",
       "require": "./cjs/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "main": "cjs/index.js",
   "jsdelivr": "umd/index.js",


### PR DESCRIPTION
For some front-end framework like React or Svelte, the package.json file need to be exported. This change is not impacting anything else.